### PR TITLE
Preserve the order of list items and object fields in arguments

### DIFF
--- a/src/GraphQL/Operations/CanonicalAST.elm
+++ b/src/GraphQL/Operations/CanonicalAST.elm
@@ -836,7 +836,7 @@ renderArgumentsExp args cursor =
             cursor
 
         _ ->
-            List.foldr
+            List.foldl
                 (\arg ( afterFirst, curs ) ->
                     ( True
                     , curs
@@ -901,7 +901,7 @@ addArgValue val cursor =
                     )
 
         AST.Object keyVals ->
-            List.foldr
+            List.foldl
                 (\( key, innerVal ) ( afterFirst, curs ) ->
                     ( True
                     , curs

--- a/src/GraphQL/Operations/CanonicalAST.elm
+++ b/src/GraphQL/Operations/CanonicalAST.elm
@@ -925,7 +925,7 @@ addArgValue val cursor =
                 |> addString "}"
 
         AST.ListValue vals ->
-            List.foldr
+            List.foldl
                 (\innerVal ( afterFirst, curs ) ->
                     ( True
                     , curs


### PR DESCRIPTION
The order of list argument items and object argument fields is reversed because `elm-gql` constructs the string by folding from the right. 
This PR fixes that by folding from the left instead.